### PR TITLE
added options (rel:, tomsg:, tofeed:, toext:) to all fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Message-processing tools for secure-scuttlebutt
 var mlib = require('ssb-msgs')
 ```
 
-### indexLinks(msg: Object, each: Function(link: Object))
+### indexLinks(msg: Object, [opts: { rel: String, tomsg: Bool, tofeed: Bool, toext: Bool },] each: Function(link: Object))
 
-Traverses an message and runs the `each` function on all found links.
+Traverses an message and runs the `each` function on all found links. All `opts` fields are optional. `Opts` may also be a string, in which case it is the rel attribute
 
 ```js
 var msg = {
@@ -23,11 +23,26 @@ mlib.indexLinks(msg, function(link) {
 // output:
 // 'foo-link' 'id...'
 // 'baz-link' 'id...'
+mlib.indexLinks(msg, { rel: 'foo-link' }, function(link) {
+  console.log(link.rel, link.msg || link.feed || link.ext)
+})
+// output:
+// 'foo-link' 'id...'
+mlib.indexLinks(msg, 'foo-link', function(link) {
+  console.log(link.rel, link.msg || link.feed || link.ext)
+})
+// output:
+// 'foo-link' 'id...'
+mlib.indexLinks(msg, { tofeed: true }, function(link) {
+  console.log(link.rel, link.feed)
+})
+// output:
+// 'baz-link' 'id...'
 ```
 
-### getLinks(msg: Object, [rel: String])
+### getLinks(msg: Object, [opts: { rel: String, tomsg: Bool, tofeed: Bool, toext: Bool }])
 
-Traverses a message and returns all found links.
+Traverses a message and returns all found links. `Opts` works as in the `indexLinks` function
 
 ```js
 var msg = {
@@ -39,7 +54,13 @@ var msg = {
 console.log(mlib.getLinks(msg))
 // output:
 // [ {rel: 'foo-link', msg: 'id...'}, {rel: 'baz-link', feed: 'id...'}]
+console.log(mlib.getLinks(msg, { rel: 'foo-link' }))
+// output:
+// [ {rel: 'foo-link', msg: 'id...'}]
 console.log(mlib.getLinks(msg, 'foo-link'))
 // output:
 // [ {rel: 'foo-link', msg: 'id...'}]
+console.log(mlib.getLinks(msg, { tofeed: true }))
+// output:
+// [ {rel: 'baz-link', msg: 'id...'}]
 ```

--- a/index.js
+++ b/index.js
@@ -8,19 +8,31 @@ function traverse (obj, each) {
   }
 }
 
-exports.indexLinks = function (msg, each) {
+exports.indexLinks = function (msg, opts, each) {
+  if (typeof opts == 'function') {
+    each = opts
+    opts = null
+  }
+  if (typeof opts == 'string')
+    opts = { rel: opts }
+  var _rel    = (opts && opts.rel)
+  var _tomsg  = (opts && opts.tomsg)
+  var _tofeed = (opts && opts.tofeed)
+  var _toext  = (opts && opts.toext)
   traverse(msg, function (obj) {
-    if(obj.rel && (obj.msg || obj.ext || obj.feed)) each(obj)
+    if (!obj.rel || (_rel && obj.rel !== _rel)) return
+    if (_tomsg  && !obj.msg) return
+    if (_tofeed && !obj.feed) return
+    if (_toext  && !obj.ext) return
+    if (!(obj.msg || obj.ext || obj.feed)) return
+    each(obj)
   })
 }
 
-exports.getLinks = function(msg, rel) {
+exports.getLinks = function(msg, opts) {
   var links = []
-  exports.indexLinks(msg, function(link) {
-    if (!rel)
-      links.push(link)
-    else if (link.rel == rel)
-      links.push(link)
+  exports.indexLinks(msg, opts, function (link) {
+    links.push(link)
   })
   return links
 }


### PR DESCRIPTION
new signatures

`indexLinks(msg: Object, [opts: { rel: String, tomsg: Bool, tofeed: Bool, toext: Bool },] each: Function(link: Object))`
`getLinks(msg: Object, [opts: { rel: String, tomsg: Bool, tofeed: Bool, toext: Bool }])`

the `toX` options filter by link type and can be combined. eg for links that reference feeds and messages, you'd use `{ tomsg: true, tofeed: true }`