### PR TITLE
treat array-like link objects as arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,37 @@ function isObject (o) { return o && 'object' === typeof o }
 function isBool (o) { return 'boolean' === typeof o }
 function isString (s) { return 'string' === typeof s }
 
+function toArray (v, force) {
+  if (Array.isArray(v))
+    return v
+
+  // maybe it's an array-like object? (object with ordered numeric keys)
+  var i=0, arr=[]
+  if (isObject(v)) {
+    while (v[i]) {
+      arr[i] = v[i]
+      i++
+    }
+    if (Object.keys(arr).length > 0)
+      return arr // it was!
+  }
+
+  // it wasnt...
+  if (force) {
+    // ...just put v in the arr
+    arr.push(v)
+    return arr
+  }
+  return v
+}
+
 function traverse (obj, each) {
   for (var k in obj) {
     if (!obj[k])
       continue
-    if (Array.isArray(obj[k])) {
-      obj[k].forEach(function (v) {
+    var arr = toArray(obj[k], false)
+    if (Array.isArray(arr)) {
+      arr.forEach(function (v) {
         each(v, k)
       })
     } else
@@ -71,7 +96,7 @@ exports.links =
 exports.asLinks = function (obj, type) {
   if (!obj)
     return []
-  var arr = Array.isArray(obj) ? obj : [obj]
+  var arr = toArray(obj, true)
   return arr
     .filter(function (l) { return isLink(l, type) })
     .map(function (o) { return (typeof o == 'string') ? { link: o } : o })

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,8 @@ module.exports = function () {
       // none of these will be indexed
       j: feedid,
       k: { link: feedid }
-    }
+    },
+    j: { 0: feedid, 1: msgid, 2: blobid } // array-like object, treated like an array
   }
 
   tape('link', function (t) {
@@ -94,6 +95,7 @@ module.exports = function () {
     t.deepEqual(mlib.links(msg.h, 'feed'), [{ link: feedid, foo: true }])
     t.deepEqual(mlib.links(msg.h, 'msg'), [{ link: msgid, foo: true }])
     t.deepEqual(mlib.links(msg.h, 'blob'), [{ link: blobid, foo: true }])
+    t.deepEqual(mlib.links(msg.j), [{ link: feedid }, { link: msgid }, { link: blobid }])
 
     t.end()
 
@@ -121,7 +123,10 @@ module.exports = function () {
       { link: blobid },
       { link: feedid, foo: true },
       { link: msgid, foo: true },
-      { link: blobid, foo: true }
+      { link: blobid, foo: true },
+      { link: feedid },
+      { link: msgid },
+      { link: blobid }
     ])
     t.deepEqual(index('a'), [{ link: feedid }])
     t.deepEqual(index({ rel: 'a' }), [{ link: feedid }])
@@ -131,19 +136,22 @@ module.exports = function () {
       { link: feedid },
       { link: feedid, foo: true },
       { link: feedid },
-      { link: feedid, foo: true }
+      { link: feedid, foo: true },
+      { link: feedid }
     ])
     t.deepEqual(index({ msg: true }), [
       { link: msgid },
       { link: msgid, foo: true },
       { link: msgid },
-      { link: msgid, foo: true }
+      { link: msgid, foo: true },
+      { link: msgid }
     ])
     t.deepEqual(index({ blob: true }), [
       { link: blobid },
       { link: blobid, foo: true },
       { link: blobid },
-      { link: blobid, foo: true }
+      { link: blobid, foo: true },
+      { link: blobid }
     ])
 
     t.end()


### PR DESCRIPTION
I noticed that arrays in the command-line were getting processed into objects. Example:

```
sbot publish ... --mentions.0.link @... --mentions.0.name paul
```

came out:

```js
{ mentions: { 0: { link: '@...', name: 'paul' } } }
```

Maybe I got minimist's CLI syntax for arrays wrong, but this seems like a common mistake to make. So I figured, why not just treat array-like objects like arrays?

This PR does that. @dominictarr lmk if you think there's any reason *not* to do this.