### PR TITLE
add linksTo and relationsTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,27 @@ mlib.isLink(msg.bar, 'feed') // => true
 mlib.isLink(msg.bar, 'msg') // => false
 mlib.isLink(msg.baz) // => false
 ```
+
+### linksTo
+
+```
+linksTo(a: Message, b: Message)
+```
+
+Get link objects pointing from `a` to `b`.
+
+```js
+mlib.linksTo(msgA, msgB) // => [{ link: '%msgB-id' }]
+```
+
+### relationsTo
+
+```
+relationsTo(a: Message, b: Message)
+```
+
+Get relations of links pointing from `a` to `b`.
+
+```js
+mlib.relationsTo(msgA, msgB) // => ['fooRelation']
+```

--- a/index.js
+++ b/index.js
@@ -28,6 +28,18 @@ function toArray (v, force) {
   return v
 }
 
+// given any part of the message-obj hierarchy, pull out the content-object
+// - uses ducktyping to find the content
+function toMsgContent (obj) {
+  if (!obj)
+    return null
+  if (obj.value && obj.value.content && obj.value.content.type)
+    return obj.value.content
+  if (obj.content && obj.content.type)
+    return obj.content
+  return obj
+}
+
 function traverse (obj, each) {
   for (var k in obj) {
     if (!obj[k])
@@ -42,6 +54,7 @@ function traverse (obj, each) {
   }
 }
 
+// iterate links in the message
 exports.indexLinks = function (message, opts, each) {
   if (typeof opts == 'function') {
     each = opts
@@ -56,7 +69,7 @@ exports.indexLinks = function (message, opts, each) {
   var blob = opts.blob
   var any  = !(msg || feed || blob)
 
-  traverse(message, function (obj, rel) {
+  traverse(toMsgContent(message), function (obj, rel) {
     if (opts.rel && rel !== opts.rel) return
 
     var r = (typeof obj == 'string') ? obj : obj.link
@@ -83,6 +96,8 @@ exports.indexLinks = function (message, opts, each) {
   })
 }
 
+// coerce to link object, optionally of a given type
+// null if coersion fails
 exports.link =
 exports.asLink = function (obj, type) {
   if (!obj)
@@ -92,6 +107,8 @@ exports.asLink = function (obj, type) {
   return isLink(obj, type) ? obj : null
 }
 
+// coerce to links array, optionally of a given type
+// filters out failed coersions
 exports.links =
 exports.asLinks = function (obj, type) {
   if (!obj)
@@ -102,10 +119,39 @@ exports.asLinks = function (obj, type) {
     .map(function (o) { return (typeof o == 'string') ? { link: o } : o })
 }
 
+// detects whether the given string/object is a link
+// - `type` optional
 var isLink =
 exports.isLink = function (obj, type) {
   if (!obj)
     return false
   var r = (isString(obj)) ? obj : obj.link
   return (type) ? (ref.type(r) == type) : ref.isLink(r)
+}
+
+function indexLinksTo (msgA, msgB, each) {
+  if (!msgA || !msgB || !msgB.key)
+    return
+  exports.indexLinks(msgA, function (l, rel) {
+    if (l.link === msgB.key)
+      each(l, rel)
+  })
+}
+
+// iterate `msgA` and find all links to `msgB`, returning an array of the link objects
+exports.linksTo = function (msgA, msgB) {
+  var links = []
+  indexLinksTo(msgA, msgB, function (link, rel) {
+    links.push(link)
+  })
+  return links
+}
+
+// iterate `msgA` and find all links to `msgB`, returning an array of the link rels 
+exports.relationsTo = function (msgA, msgB) {
+  var rels = []
+  indexLinksTo(msgA, msgB, function (link, rel) {
+    rels.push(rel)
+  })
+  return rels
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ var mlib = require('../index')
 module.exports = function () {
   var feedid = '@nUtgCIpqOsv6k5mnWKA4JeJVkJTd9Oz2gmv6rojQeXU=.ed25519'
   var msgid = '%MPB9vxHO0pvi2ve2wh6Do05ZrV7P6ZjUQ+IEYnzLfTs=.sha256'
+  var msgid2 = '%NPB9vxHO0pvi2ve2wh6Do05ZrV7P6ZjUQ+IEYnzLfTs=.sha256'
   var blobid = '&Pe5kTo/V/w4MToasp1IuyMrMcCkQwDOdyzbyD5fy4ac=.sha256'
 
   var msg = {
@@ -156,6 +157,48 @@ module.exports = function () {
 
     t.end()
 
+  })
+
+  tape('linksTo, relationsTo', function (t) {
+    var msg1 = {
+      key: msgid,
+      value: {
+        content: {
+          type: 'foo',
+          rel1: msgid2,
+          rel2: [msgid2],
+          rel3: { link: msgid2 },
+          rel4: [{ link: msgid2 }]
+        }
+      }
+    }
+    var msg2 = {
+      key: msgid2,
+      value: {
+        content: {
+          type: 'foo',
+          rel5: msgid,
+          rel6: [msgid],
+          rel7: { link: msgid },
+          rel8: [{ link: msgid }]
+        }
+      }
+    }
+    t.deepEqual(mlib.linksTo(msg1, msg2), [
+      { link: msgid2 },
+      { link: msgid2 },
+      { link: msgid2 },
+      { link: msgid2 }
+    ])
+    t.deepEqual(mlib.relationsTo(msg1, msg2), ['rel1', 'rel2', 'rel3', 'rel4'])
+    t.deepEqual(mlib.linksTo(msg2, msg1), [
+      { link: msgid },
+      { link: msgid },
+      { link: msgid },
+      { link: msgid }
+    ])
+    t.deepEqual(mlib.relationsTo(msg2, msg1), ['rel5', 'rel6', 'rel7', 'rel8'])
+    t.end()
   })
 }
 


### PR DESCRIPTION
Add two funcs to enumerate links, or link-relations, between two messages.

Here's an example usage:

```js
function isaReplyTo (a, b) {
  var rels = mlib.relationsTo(a, b)
  return rels.indexOf('root') >= 0 || rels.indexOf('branch') >= 0
}
```