### PR TITLE
fix #10: don't assume obj prop in indexLinks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 var ref = require('ssb-ref')
 
-function isObject (o) { return o && 'object' === typeof o }
-function isBool (o) { return 'boolean' === typeof o }
-function isString (s) { return 'string' === typeof s }
+function isObject(o) { return o && 'object' === typeof o }
+function isBool(o) { return 'boolean' === typeof o }
+function isString(s) { return 'string' === typeof s }
 
-function toArray (v, force) {
+function toArray(v, force) {
   if (Array.isArray(v))
     return v
 
   // maybe it's an array-like object? (object with ordered numeric keys)
-  var i=0, arr=[]
+  var i = 0, arr = []
   if (isObject(v)) {
     while (v[i]) {
       arr[i] = v[i]
@@ -30,7 +30,7 @@ function toArray (v, force) {
 
 // given any part of the message-obj hierarchy, pull out the content-object
 // - uses ducktyping to find the content
-function toMsgContent (obj) {
+function toMsgContent(obj) {
   if (!obj)
     return null
   if (obj.value && obj.value.content && obj.value.content.type)
@@ -40,7 +40,7 @@ function toMsgContent (obj) {
   return obj
 }
 
-function traverse (obj, each) {
+function traverse(obj, each) {
   for (var k in obj) {
     if (!obj[k])
       continue
@@ -64,30 +64,37 @@ exports.indexLinks = function (message, opts, each) {
     opts = { rel: opts }
   if (!opts)
     opts = {}
-  var msg  = opts.msg
+  var msg = opts.msg
   var feed = opts.feed
   var blob = opts.blob
-  var any  = !(msg || feed || blob)
+  var any = !(msg || feed || blob)
 
   traverse(toMsgContent(message), function (obj, rel) {
     if (opts.rel && rel !== opts.rel) return
 
-    var r = (typeof obj == 'string') ? obj : obj.link
+    var r;
+    if (typeof obj == 'string') {
+      r = obj
+    } else if (typeof obj.link !== "undefined") {
+      r = obj.link
+    } else {
+      return
+    }
     if (any) {
       if (!ref.isLink(r)) return
     } else {
       if (msg) {
-        if (isBool(msg) && ref.type(r) != 'msg') return 
+        if (isBool(msg) && ref.type(r) != 'msg') return
         if (!isBool(msg) && r != msg) return
       }
 
       if (feed) {
-        if (isBool(feed) && ref.type(r) != 'feed') return 
+        if (isBool(feed) && ref.type(r) != 'feed') return
         if (!isBool(feed) && r != feed) return
       }
 
       if (blob) {
-        if (isBool(blob) && ref.type(r) != 'blob') return 
+        if (isBool(blob) && ref.type(r) != 'blob') return
         if (!isBool(blob) && r != blob) return
       }
     }
@@ -99,37 +106,37 @@ exports.indexLinks = function (message, opts, each) {
 // coerce to link object, optionally of a given type
 // null if coersion fails
 exports.link =
-exports.asLink = function (obj, type) {
-  if (!obj)
-    return null
-  if (isString(obj))
-    obj = { link: obj }
-  return isLink(obj, type) ? obj : null
-}
+  exports.asLink = function (obj, type) {
+    if (!obj)
+      return null
+    if (isString(obj))
+      obj = { link: obj }
+    return isLink(obj, type) ? obj : null
+  }
 
 // coerce to links array, optionally of a given type
 // filters out failed coersions
 exports.links =
-exports.asLinks = function (obj, type) {
-  if (!obj)
-    return []
-  var arr = toArray(obj, true)
-  return arr
-    .filter(function (l) { return isLink(l, type) })
-    .map(function (o) { return (typeof o == 'string') ? { link: o } : o })
-}
+  exports.asLinks = function (obj, type) {
+    if (!obj)
+      return []
+    var arr = toArray(obj, true)
+    return arr
+      .filter(function (l) { return isLink(l, type) })
+      .map(function (o) { return (typeof o == 'string') ? { link: o } : o })
+  }
 
 // detects whether the given string/object is a link
 // - `type` optional
 var isLink =
-exports.isLink = function (obj, type) {
-  if (!obj)
-    return false
-  var r = (isString(obj)) ? obj : obj.link
-  return (type) ? (ref.type(r) == type) : ref.isLink(r)
-}
+  exports.isLink = function (obj, type) {
+    if (!obj)
+      return false
+    var r = (isString(obj)) ? obj : obj.link
+    return (type) ? (ref.type(r) == type) : ref.isLink(r)
+  }
 
-function indexLinksTo (msgA, msgB, each) {
+function indexLinksTo(msgA, msgB, each) {
   if (!msgA || !msgB || !msgB.key)
     return
   exports.indexLinks(msgA, function (l, rel) {

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ exports.indexLinks = function (message, opts, each) {
     var r;
     if (typeof obj == 'string') {
       r = obj
-    } else if (typeof obj.link !== "undefined") {
+    } else if (typeof obj.link == 'string') {
       r = obj.link
     } else {
       return

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ exports.indexLinks = function (message, opts, each) {
     var r;
     if (typeof obj == 'string') {
       r = obj
-    } else if (typeof obj.link == 'string') {
+    } else if (obj && typeof obj.link == 'string') {
       r = obj.link
     } else {
       return


### PR DESCRIPTION
After breaking my _sbot_ five times today I came to realize that having a broken _mentions_ array in a post will prevent _sbot_ from starting. This was narrowed down to this module assuming all links in `indexLinks` were either a string or an object with a `link` property. I've added code to ignore items that are not these two cases.